### PR TITLE
Added support for custom login and error pages

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	cookieDomain            = flag.String("cookie-domain", "", "an optional cookie domain to force cookies to")
 	googleAppsDomain        = flag.String("google-apps-domain", "", "authenticate against the given google apps domain")
 	authenticatedEmailsFile = flag.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
+	templatePath            = flag.String("template-path", "", "directory containing sign_in.html and error.html")
 	upstreams               = StringArray{}
 )
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -192,6 +192,9 @@ func (p *OauthProxy) ErrorPage(rw http.ResponseWriter, code int, title string, m
 	log.Printf("ErrorPage %d %s %s", code, title, message)
 	rw.WriteHeader(code)
 	templates := getTemplates()
+	if *templatePath != ""  {
+		templates = getTemplateFiles(*templatePath)
+	}
 	t := struct {
 		Title   string
 		Message string
@@ -206,6 +209,9 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	p.ClearCookie(rw, req)
 	rw.WriteHeader(code)
 	templates := getTemplates()
+	if *templatePath != ""  {
+		templates = getTemplateFiles(*templatePath)
+	}
 
 	t := struct {
 		SignInMessage string

--- a/templates.go
+++ b/templates.go
@@ -49,3 +49,11 @@ func getTemplates() *template.Template {
 	}
 	return t
 }
+
+func getTemplateFiles(path string) *template.Template {
+	t, err := template.New("foo").ParseFiles(path + "/sign_in.html", path + "/error.html")
+	if err != nil {
+		log.Fatalf("failed parsing template files %s", err.Error())
+	}
+	return t
+}


### PR DESCRIPTION
Fixes #11

I have never written code in golang before, so please review this carefully.

It allows you to pass a `template-path` flag (eg. `--template-path="/var/www/auth"`), which must point to a directory containing `sign_in.html` and `error.html`. If this flag is present, it renders those templates instead of the built-in templates.