### PR TITLE
#43 – Proxied requests use the Upstream Host Header.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -42,7 +42,13 @@ type OauthProxy struct {
 }
 
 func NewReverseProxy(target *url.URL) (proxy *httputil.ReverseProxy) {
-    return httputil.NewSingleHostReverseProxy(target)
+    proxy = httputil.NewSingleHostReverseProxy(target)
+    director := proxy.Director
+    proxy.Director = func(req *http.Request) {
+        director(req)
+        req.Host = target.Host
+    }
+    return proxy
 }
 
 func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -41,6 +41,10 @@ type OauthProxy struct {
 	PassBasicAuth      bool
 }
 
+func NewReverseProxy(target *url.URL) (proxy *httputil.ReverseProxy) {
+    return httputil.NewSingleHostReverseProxy(target)
+}
+
 func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 	login, _ := url.Parse("https://accounts.google.com/o/oauth2/auth")
 	redeem, _ := url.Parse("https://accounts.google.com/o/oauth2/token")
@@ -49,7 +53,7 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 		path := u.Path
 		u.Path = ""
 		log.Printf("mapping path %q => upstream %q", path, u)
-		serveMux.Handle(path, httputil.NewSingleHostReverseProxy(u))
+		serveMux.Handle(path, NewReverseProxy(u))
 	}
 	redirectUrl := opts.redirectUrl
 	redirectUrl.Path = oauthCallbackPath

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestNewReverseProxy(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+        hostname, _, _ := net.SplitHostPort(r.Host)
+		w.Write([]byte(hostname))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	backendHostname := "upstream.127.0.0.1.xip.io"
+	_, backendPort, _ := net.SplitHostPort(backendURL.Host)
+	backendHost := net.JoinHostPort(backendHostname, backendPort)
+	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
+
+	proxyHandler := NewReverseProxy(proxyURL)
+	frontend := httptest.NewServer(proxyHandler)
+	defer frontend.Close()
+
+	getReq, _ := http.NewRequest("GET", frontend.URL, nil)
+	res, _ := http.DefaultClient.Do(getReq)
+	bodyBytes, _ := ioutil.ReadAll(res.Body)
+	if g, e := string(bodyBytes), backendHostname; g != e {
+		t.Errorf("got body %q; expected %q", g, e)
+	}
+}


### PR DESCRIPTION
Hey @jehiah, here is a first take on an implementation of #43.

Could you provide feedback on the following:

1. This change breaks backwards compatibility in original Host header is no longer sent upstream. Would you like me to force the user to pass a flag (as in #1) to enable this new behaviour?
2. For the test, I was inspired by the [`reverseproxy` module's tests](http://golang.org/src/pkg/net/http/httputil/reverseproxy_test.go) to create a Host header echo server. It wasn't immediately clear which hostname I could use that would always to the local server... so I cheated and used xip.io. Any thoughts on how to not involve an this external dependancy?

Thanks!