### PR TITLE
Support for multi white listed urls with regex url match.

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 
 	googleAppsDomains := StringArray{}
 	upstreams := StringArray{}
+	skipAuthRegex := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -27,6 +28,7 @@ func main() {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint. If multiple, routing is based on path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
+	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 
 	flagSet.Var(&googleAppsDomains, "google-apps-domain", "authenticate against the given Google apps domain (may be given multiple times)")
 	flagSet.String("client-id", "", "the Google OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")


### PR DESCRIPTION
Sample Command to run multi whitelisted urls with regex.

./google_auth_proxy \
  --redirect-url="http://yourcallbackurl.com/oauth2/callback"  \
  --google-apps-domain="yourdomain.com" \
  --upstream=http://127.0.0.1:8080 \
  --cookie-secret="nuts"\
  --client-id="your client id" \
  --client-secret="your client secret"  \
  --cookie-expire=0h30m0s \
  --cookie-https-only=false \
  --skip-auth-regex="/hello.php","/status.php","/health-check-url/*"