### PR TITLE
Set the default redirect-uri hostname to be the request hostname

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "<addr>:<port> to listen on for HTTP clients")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.Bool("redirect-to-https", false, "set default redirect-url to https")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint. If multiple, routing is based on path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,7 @@ import (
 type Options struct {
 	HttpAddress             string        `flag:"http-address" cfg:"http_address"`
 	RedirectUrl             string        `flag:"redirect-url" cfg:"redirect_url"`
+	RedirectToHttps         bool          `flag:"redirect-to-https" cfg:"redirect-to-https"`
 	ClientID                string        `flag:"client-id" cfg:"client_id" env:"GOOGLE_AUTH_PROXY_CLIENT_ID"`
 	ClientSecret            string        `flag:"client-secret" cfg:"client_secret" env:"GOOGLE_AUTH_PROXY_CLIENT_SECRET"`
 	PassBasicAuth           bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
@@ -33,6 +34,7 @@ func NewOptions() *Options {
 	return &Options{
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
+		RedirectToHttps:     false,
 		CookieHttpsOnly:     true,
 		PassBasicAuth:       true,
 		CookieExpire:        time.Duration(168) * time.Hour,


### PR DESCRIPTION
Also add a flag to redirect to an https version of that hostname

If your request to google_auth_proxy is the following
    GET /someurl HTTP/1.1
    Host: somedomain.com
and redirect-url is set to ""

redirect-url will be set to http://somedomain.com/oauth2/callback
  or
redirect-url will be set to https://somedomain.com/oauth2/callback
if redirect-to-https flag is set.