### PR TITLE
Add custom SignInMessage as command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Usage of google_auth_proxy:
   -http-address="127.0.0.1:4180": <addr>:<port> to listen on for HTTP clients
   -pass-basic-auth=true: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
   -redirect-url="": the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
+  -sign-in-message="": set custom text or HTML to be displayed as the sign in message
   -upstream=: the http url(s) of the upstream endpoint. If multiple, routing is based on path
   -version=false: print version string
 ```

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func main() {
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
 	flagSet.Bool("cookie-https-only", true, "set HTTPS only cookie")
 
+	flagSet.String("sign-in-message", "", "set custom text or HTML to be displayed as the sign in message")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
@@ -69,7 +71,7 @@ func main() {
 	oauthproxy := NewOauthProxy(opts, validator)
 
 	if len(opts.GoogleAppsDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
-		if opts.CustomSignInMessage {
+		if opts.CustomSignInMessage != "" {
 			oauthproxy.SignInMessage = opts.CustomSignInMessage
 		} else {
 			if len(opts.GoogleAppsDomains) > 1 {
@@ -103,3 +105,4 @@ func main() {
 
 	log.Printf("HTTP: closing %s", listener.Addr())
 }
+

--- a/main.go
+++ b/main.go
@@ -69,10 +69,14 @@ func main() {
 	oauthproxy := NewOauthProxy(opts, validator)
 
 	if len(opts.GoogleAppsDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
-		if len(opts.GoogleAppsDomains) > 1 {
-			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using one of the following domains: %v", strings.Join(opts.GoogleAppsDomains, ", "))
+		if opts.CustomSignInMessage {
+			oauthproxy.SignInMessage = opts.CustomSignInMessage
 		} else {
-			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using %v", opts.GoogleAppsDomains[0])
+			if len(opts.GoogleAppsDomains) > 1 {
+				oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using one of the following domains: %v", strings.Join(opts.GoogleAppsDomains, ", "))
+			} else {
+				oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using %v", opts.GoogleAppsDomains[0])
+			}
 		}
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"html/template"
 
 	"github.com/bitly/go-simplejson"
 )
@@ -236,12 +237,12 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	templates := getTemplates()
 
 	t := struct {
-		SignInMessage string
+		SignInMessage template.HTML
 		CustomLogin   bool
 		Redirect      string
 		Version       string
 	}{
-		SignInMessage: p.SignInMessage,
+		SignInMessage: template.HTML(p.SignInMessage),
 		CustomLogin:   p.displayCustomLoginForm(),
 		Redirect:      req.URL.RequestURI(),
 		Version:       VERSION,

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	AuthenticatedEmailsFile string        `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	GoogleAppsDomains       []string      `flag:"google-apps-domain" cfg:"google_apps_domains"`
 	Upstreams               []string      `flag:"upstream" cfg:"upstreams"`
+	CustomSignInMessage     string        `flag:"sign-in-message" cfg:"sign_in_message"`
 
 	// internal values that are set after config validation
 	redirectUrl *url.URL


### PR DESCRIPTION
This code adds a custom SignInMessage as a command line parameter. 

This allows arbitrary HTML to be passed in via the command line as well. 

The specific use case for this is that I am embedding a google-auth-proxy protected resource in an iframe, and the google auth servers don't allow this type of request to be done inside an iframe. I can work around it by adding some instructions and a link that opens in a new window to the sign in template. 