### PR TITLE
Rename flag to set Secure flag on cookie

### DIFF
--- a/contrib/google_auth_proxy.cfg.example
+++ b/contrib/google_auth_proxy.cfg.example
@@ -41,4 +41,4 @@
 # cookie_secret = ""
 # cookie_domain = ""
 # cookie_expire = "168h"
-# cookie_https_only = true
+# cookie_secure = true

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
-	flagSet.Bool("cookie-https-only", true, "set HTTPS only cookie")
+	flagSet.Bool("cookie-secure", true, "set Secure flag on cookie")
 
 	flagSet.Parse(os.Args[1:])
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -23,12 +23,12 @@ const oauthStartPath = "/oauth2/start"
 const oauthCallbackPath = "/oauth2/callback"
 
 type OauthProxy struct {
-	CookieSeed      string
-	CookieKey       string
-	CookieDomain    string
-	CookieHttpsOnly bool
-	CookieExpire    time.Duration
-	Validator       func(string) bool
+	CookieSeed   string
+	CookieKey    string
+	CookieDomain string
+	CookieSecure bool
+	CookieExpire time.Duration
+	Validator    func(string) bool
 
 	redirectUrl         *url.URL // the url to receive requests at
 	oauthRedemptionUrl  *url.URL // endpoint to redeem the code
@@ -67,14 +67,14 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 	if domain == "" {
 		domain = "<default>"
 	}
-	log.Printf("Cookie settings: https_only: %v expiry: %s domain:%s", opts.CookieHttpsOnly, opts.CookieExpire, domain)
+	log.Printf("Cookie settings: secure: %v expiry: %s domain:%s", opts.CookieSecure, opts.CookieExpire, domain)
 	return &OauthProxy{
-		CookieKey:       "_oauthproxy",
-		CookieSeed:      opts.CookieSecret,
-		CookieDomain:    opts.CookieDomain,
-		CookieHttpsOnly: opts.CookieHttpsOnly,
-		CookieExpire:    opts.CookieExpire,
-		Validator:       validator,
+		CookieKey:    "_oauthproxy",
+		CookieSeed:   opts.CookieSecret,
+		CookieDomain: opts.CookieDomain,
+		CookieSecure: opts.CookieSecure,
+		CookieExpire: opts.CookieExpire,
+		Validator:    validator,
 
 		clientID:           opts.ClientID,
 		clientSecret:       opts.ClientSecret,
@@ -214,7 +214,7 @@ func (p *OauthProxy) SetCookie(rw http.ResponseWriter, req *http.Request, val st
 		Path:     "/",
 		Domain:   domain,
 		HttpOnly: true,
-		Secure:   p.CookieHttpsOnly,
+		Secure:   p.CookieSecure,
 		Expires:  time.Now().Add(p.CookieExpire),
 	}
 	http.SetCookie(rw, cookie)

--- a/options.go
+++ b/options.go
@@ -20,7 +20,7 @@ type Options struct {
 	CookieSecret            string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
 	CookieDomain            string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
 	CookieExpire            time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
-	CookieHttpsOnly         bool          `flag:"cookie-https-only" cfg:"cookie_https_only"`
+	CookieSecure            bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	AuthenticatedEmailsFile string        `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	GoogleAppsDomains       []string      `flag:"google-apps-domain" cfg:"google_apps_domains"`
 	Upstreams               []string      `flag:"upstream" cfg:"upstreams"`
@@ -36,7 +36,7 @@ func NewOptions() *Options {
 	return &Options{
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
-		CookieHttpsOnly:     true,
+		CookieSecure:        true,
 		PassBasicAuth:       true,
 		CookieExpire:        time.Duration(168) * time.Hour,
 	}


### PR DESCRIPTION
As mentioned in #57, I've added this as a separate pull request. I think it makes it clearer, but it's a breaking change.