### PR TITLE
Adds User group membership info to headers

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,3 +2,7 @@ github.com/BurntSushi/toml              3883ac1ce943878302255f538fce319d23226223
 github.com/bitly/go-simplejson          3378bdcb5cebedcbf8b5750edee28010f128fe24
 github.com/mreiferson/go-options        ee94b57f2fbf116075426f853e5abbcdfeca8b3d
 github.com/bmizerany/assert             e17e99893cb6509f428e1728281c2ad60a6b31e3
+google.golang.org/api/admin/directory_v1	fc402b0d6f2a46ba7dcf0a4606031f45fb82a728
+golang.org/x/oauth2
+golang.org/x/oauth2/google
+golang.org/x/net/context

--- a/cookies.go
+++ b/cookies.go
@@ -9,12 +9,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"log"
 )
 
 func validateCookie(cookie *http.Cookie, seed string) (string, bool) {
 	// value, timestamp, sig
 	parts := strings.Split(cookie.Value, "|")
 	if len(parts) != 3 {
+		log.Printf("Cookie %s does not have 3 parts, not valid", cookie.Name)
 		return "", false
 	}
 	sig := cookieSignature(seed, cookie.Name, parts[0], parts[1])

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -458,7 +458,6 @@ func (p *OauthProxy) GetGroupJson(email string, token *oauth2.Token) string {
 	adminService, err := directory.New(c)
 
 	res, err := adminService.Groups.List().UserKey(email).Do()
-	log.Printf("Got directory.Groups.List().UserKey(%s), err: %#v, %v", email, res, err)
 
 	simpleGroups := make([]string, len(res.Groups))
 
@@ -467,8 +466,6 @@ func (p *OauthProxy) GetGroupJson(email string, token *oauth2.Token) string {
 	}
 
 	b, err := json.Marshal(simpleGroups)
-
-	log.Printf("Returning json: %v", string(b[:]))
 
 	return string(b[:])
 }

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -394,7 +394,7 @@ func (p *OauthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				roleString, err := p.GetGroupJson(email, token)
 
 				if (!err) {
-					p.SetCookie(rw, req, p.CookieKey+"Roles",)
+					p.SetCookie(rw, req, p.CookieKey+"Roles", roleString)
 				}
 			}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -401,6 +401,8 @@ func (p *OauthProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				HttpOnly: p.CookieHttpOnly,
 			}
 
+			log.Printf("setting roles cookie: %s", cookie)
+
 			http.SetCookie(rw, cookie)
 
 			http.Redirect(rw, req, redirect, 302)


### PR DESCRIPTION
This PR uses the google go admin SDK to determine the group memberships of the authenticating user and stores the list of groups in a signed cookie, and then passes that group list (if valid) forward to the upstream server in the HTTP headers.

See issue #28.

Note that this is my first Go code, so if I'm doing things that are not idiomatic or not organized correctly, please let me know and I can update the PR.

Thanks.