### PR TITLE
make redirect-uri optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ The command line to run `google_auth_proxy` would look like this:
 
 ```bash
 ./google_auth_proxy \
-   --redirect-url="https://internal.yourcompany.com/oauth2/callback"  \
    --google-apps-domain="yourcompany.com"  \
    --upstream=http://127.0.0.1:8080/ \
    --cookie-secret=... \
@@ -134,4 +133,4 @@ Google Auth Proxy responds directly to the following endpoints. All other endpoi
 * /ping - returns an 200 OK response
 * /oauth2/sign_in - the login page, which also doubles as a sign out page (it clears cookies)
 * /oauth2/start - a URL that will redirect to start the OAuth cycle
-* /oauth2/callback - the URL used at the end of the OAuth cycle
+* /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this ass the callback url.

--- a/contrib/google_auth_proxy.cfg.example
+++ b/contrib/google_auth_proxy.cfg.example
@@ -5,6 +5,7 @@
 # http_address = "127.0.0.1:4180"
 
 ## the OAuth Redirect URL.
+# defaults to the "https://" + requested host header + "/oauth2/callback"
 # redirect_url = "https://internalapp.yourcompany.com/oauth2/callback"
 
 ## the http url(s) of the upstream endpoint. If multiple, routing is based on path

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ type Options struct {
 	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
 	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
 	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
-	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"`
+	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"` // set secure cookie flag
 	CookieHttpOnly  bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
 	Upstreams      []string `flag:"upstream" cfg:"upstreams"`


### PR DESCRIPTION
This constructs a default redirect-url using "http://" + request host header + "/oauth2/callback". This enables easy ability to secure multiple virtual hosts w/ the same GAP instance as outlined in #51