### PR TITLE
Rename flag to set secure (https) cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Usage of google_auth_proxy:
   -config="": path to config file
   -cookie-domain="": an optional cookie domain to force cookies to (ie: .yourcompany.com)*
   -cookie-expire=168h0m0s: expire timeframe for cookie
-  -cookie-httponly=true: set HttpOnly cookie
-  -cookie-https-only=true: set HTTPS only cookie
+  -cookie-httponly=true: set HttpOnly cookie flag
+  -cookie-https-only=true: set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)
   -cookie-secret="": the seed string for secure cookies
+  -cookie-secure=true: set secure (HTTPS) cookie flag
+  -custom-templates-dir="": path to custom html templates
   -display-htpasswd-form=true: display username / password login form if an htpasswd file is provided
   -google-apps-domain=: authenticate against the given Google apps domain (may be given multiple times)
   -htpasswd-file="": additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
@@ -75,7 +77,6 @@ Usage of google_auth_proxy:
   -pass-host-header=true: pass the request Host Header to upstream
   -redirect-url="": the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -skip-auth-regex=: bypass authentication for requests path's that match (may be given multiple times)
-  -custom templates-dir="": path to custom html templates
   -upstream=: the http url(s) of the upstream endpoint. If multiple, routing is based on path
   -version=false: print version string
 ```
@@ -120,7 +121,7 @@ The command line to run `google_auth_proxy` would look like this:
    --google-apps-domain="yourcompany.com"  \
    --upstream=http://127.0.0.1:8080/ \
    --cookie-secret=... \
-   --cookie-https-only=true \
+   --cookie-secure=true \
    --client-id=... \
    --client-secret=...
 ```

--- a/contrib/google_auth_proxy.cfg.example
+++ b/contrib/google_auth_proxy.cfg.example
@@ -49,5 +49,5 @@
 # cookie_secret = ""
 # cookie_domain = ""
 # cookie_expire = "168h"
-# cookie_https_only = true
+# cookie_secure = true
 # cookie_httponly = true

--- a/main.go
+++ b/main.go
@@ -43,8 +43,9 @@ func main() {
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
-	flagSet.Bool("cookie-https-only", true, "set HTTPS only cookie")
-	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie")
+	flagSet.Bool("cookie-https-only", true, "set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)")
+	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
+	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.Parse(os.Args[1:])
 

--- a/options.go
+++ b/options.go
@@ -24,7 +24,8 @@ type Options struct {
 	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
 	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
 	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
-	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"` // set secure cookie flag
+	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"` // deprecated use cookie-secure
+	CookieSecure    bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly  bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
 	Upstreams      []string `flag:"upstream" cfg:"upstreams"`
@@ -43,6 +44,7 @@ func NewOptions() *Options {
 		HttpAddress:         "127.0.0.1:4180",
 		DisplayHtpasswdForm: true,
 		CookieHttpsOnly:     true,
+		CookieSecure:        true,
 		CookieHttpOnly:      true,
 		CookieExpire:        time.Duration(168) * time.Hour,
 		PassBasicAuth:       true,


### PR DESCRIPTION
This adds a new --cookie-secure option to replace --cookie-https-only which was became confusing after a flag for httponly was added.

This replaces #59