### PR TITLE
request path contains full URL

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -67,7 +67,8 @@ func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
 	proxy.Director = func(req *http.Request) {
 		director(req)
 		// use RequestURI so that we aren't unescaping encoded slashes in the request path
-		req.URL.Opaque = fmt.Sprintf("//%s%s", target.Host, req.RequestURI)
+		req.Host = target.Host
+		req.URL.Opaque = req.RequestURI
 		req.URL.RawQuery = ""
 	}
 }
@@ -76,7 +77,7 @@ func setProxyDirector(proxy *httputil.ReverseProxy) {
 	proxy.Director = func(req *http.Request) {
 		director(req)
 		// use RequestURI so that we aren't unescaping encoded slashes in the request path
-		req.URL.Opaque = fmt.Sprintf("//%s%s", req.URL.Host, req.RequestURI)
+		req.URL.Opaque = req.RequestURI
 		req.URL.RawQuery = ""
 	}
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -51,14 +51,13 @@ func TestEncodedSlashes(t *testing.T) {
 	defer frontend.Close()
 
 	f, _ := url.Parse(frontend.URL)
-	encodedPath := "/a%2Fb/"
+	encodedPath := "/a%2Fb/?c=1"
 	getReq := &http.Request{URL: &url.URL{Scheme: "http", Host: f.Host, Opaque: encodedPath}}
 	_, err := http.DefaultClient.Do(getReq)
 	if err != nil {
 		t.Fatalf("err %s", err)
 	}
-	expected := backend.URL + encodedPath
-	if seen != expected {
-		t.Errorf("got bad request %q expected %q", seen, expected)
+	if seen != encodedPath {
+		t.Errorf("got bad request %q expected %q", seen, encodedPath)
 	}
 }


### PR DESCRIPTION
This looks like a regression in 1.1.

When I request `/` through the proxy, the upstream receives:

```
GET http://127.0.0.1:8000/ HTTP/1.1
```

The expected request would be:

```
GET / HTTP/1.1
```