### PR TITLE
Add ProviderName field; use in sign_in template

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -279,11 +279,13 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	rw.WriteHeader(code)
 
 	t := struct {
+		ProviderName  string
 		SignInMessage string
 		CustomLogin   bool
 		Redirect      string
 		Version       string
 	}{
+		ProviderName:  p.provider.Data().ProviderName,
 		SignInMessage: p.SignInMessage,
 		CustomLogin:   p.displayCustomLoginForm(),
 		Redirect:      req.URL.RequestURI(),

--- a/providers/google.go
+++ b/providers/google.go
@@ -13,6 +13,7 @@ type GoogleProvider struct {
 }
 
 func NewGoogleProvider(p *ProviderData) *GoogleProvider {
+	p.ProviderName = "Google"
 	if p.LoginUrl.String() == "" {
 		p.LoginUrl = &url.URL{Scheme: "https",
 			Host: "accounts.google.com",

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -11,15 +11,17 @@ import (
 func newGoogleProvider() *GoogleProvider {
 	return NewGoogleProvider(
 		&ProviderData{
-			LoginUrl:   &url.URL{},
-			RedeemUrl:  &url.URL{},
-			ProfileUrl: &url.URL{},
-			Scope:      ""})
+			ProviderName: "",
+			LoginUrl:     &url.URL{},
+			RedeemUrl:    &url.URL{},
+			ProfileUrl:   &url.URL{},
+			Scope:        ""})
 }
 
 func TestGoogleProviderDefaults(t *testing.T) {
 	p := newGoogleProvider()
 	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Google", p.Data().ProviderName)
 	assert.Equal(t, "https://accounts.google.com/o/oauth2/auth",
 		p.Data().LoginUrl.String())
 	assert.Equal(t, "https://accounts.google.com/o/oauth2/token",
@@ -45,6 +47,7 @@ func TestGoogleProviderOverrides(t *testing.T) {
 				Path:   "/oauth/profile"},
 			Scope: "profile"})
 	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Google", p.Data().ProviderName)
 	assert.Equal(t, "https://example.com/oauth/auth",
 		p.Data().LoginUrl.String())
 	assert.Equal(t, "https://example.com/oauth/token",

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,10 +5,11 @@ import (
 )
 
 type ProviderData struct {
-	LoginUrl   *url.URL
-	RedeemUrl  *url.URL
-	ProfileUrl *url.URL
-	Scope      string
+	ProviderName string
+	LoginUrl     *url.URL
+	RedeemUrl    *url.URL
+	ProfileUrl   *url.URL
+	Scope        string
 }
 
 func (p *ProviderData) Data() *ProviderData { return p }

--- a/templates.go
+++ b/templates.go
@@ -115,7 +115,7 @@ func getTemplates() *template.Template {
 	{{ if .SignInMessage }}
 	<p>{{.SignInMessage}}</p>
 	{{ end}}
-	<button type="submit" class="btn">Sign in with a Google Account</button><br/>
+	<button type="submit" class="btn">Sign in with a {{.ProviderName}} Account</button><br/>
 	</form>
 	</div>
 


### PR DESCRIPTION
This is the third step towards genericizing the google_auth_proxy to support OAuth2 providers other than Google as discussed in #65. Injecting the `ProviderName` into the template seems the most expedient way to reuse the default `sign_in.html` template.

Also, @jehiah, I was wondering: If you want, I can follow this PR with a PR to rename the service to `oauth2_proxy`. Otherwise, I'll go ahead and send a PR to add the MyUSA provider (plus README updates on how to add a new provider).