### PR TITLE
Redirect to / when /oauth2/sign_in accessed

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -307,6 +307,11 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 	p.ClearCookie(rw, req)
 	rw.WriteHeader(code)
 
+	redirect_url := req.URL.RequestURI()
+	if redirect_url == signInPath {
+		redirect_url = "/"
+	}
+
 	t := struct {
 		ProviderName  string
 		SignInMessage string
@@ -317,7 +322,7 @@ func (p *OauthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 		ProviderName:  p.provider.Data().ProviderName,
 		SignInMessage: p.SignInMessage,
 		CustomLogin:   p.displayCustomLoginForm(),
-		Redirect:      req.URL.RequestURI(),
+		Redirect:      redirect_url,
 		Version:       VERSION,
 	}
 	p.templates.ExecuteTemplate(rw, "sign_in.html", t)


### PR DESCRIPTION
Without this change, clicking the sign-in button on `/oauth2/sign_in` will always redirect back to `/oauth2/sign_in`, essentially creating an infinite loop.

@adelevie @esgoodman @dhcole: I've pushed an instance to the Hub with this feature integrated, and thanks to a comedy of errors, I've already pushed the "Log Out" link to the Hub as well (before issuing a PR as I'd intended). Long and short of it is, there's a working "Log Out" link on the Hub now. :-)