### PR TITLE
Authenticate client using basic authentication.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -205,6 +205,8 @@ func (p *OauthProxy) redeemCode(host, code string) (string, string, error) {
 		return "", "", err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	b64 := base64.StdEncoding.EncodeToString([]byte(p.clientID + ":" + p.clientSecret))
+	req.Header.Set("Authorization","Basic " + b64)
 	json, err := api.Request(req)
 	if err != nil {
 		log.Printf("failed making request %s", err)


### PR DESCRIPTION
According to the OAuth2 specification (http://tools.ietf.org/html/rfc6749#section-2.3.1) , the client credentials can be provided using basic authentication or request body.

This pull request adds basic authentication support.