### PR TITLE
Auto refresh auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Usage of google_auth_proxy:
   -cookie-expire=168h0m0s: expire timeframe for cookie
   -cookie-httponly=true: set HttpOnly cookie flag
   -cookie-https-only=true: set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)
-  -cookie-refresh=144h0m0s: refresh the cookie when this much time remains before expiration
+  -cookie-refresh=0: refresh the cookie when less than this much time remains before expiration; 0 to disable
   -cookie-secret="": the seed string for secure cookies
   -cookie-secure=true: set secure (HTTPS) cookie flag
   -custom-templates-dir="": path to custom html templates

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Usage of google_auth_proxy:
   -cookie-expire=168h0m0s: expire timeframe for cookie
   -cookie-httponly=true: set HttpOnly cookie flag
   -cookie-https-only=true: set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)
+  -cookie-refresh=144h0m0s: refresh the cookie when this much time remains before expiration
   -cookie-secret="": the seed string for secure cookies
   -cookie-secure=true: set secure (HTTPS) cookie flag
   -custom-templates-dir="": path to custom html templates
@@ -96,6 +97,7 @@ Usage of google_auth_proxy:
   -scope="": Oauth scope specification
   -skip-auth-regex=: bypass authentication for requests path's that match (may be given multiple times)
   -upstream=: the http url(s) of the upstream endpoint. If multiple, routing is based on path
+  -validate-url="": Access token validation endpoint
   -version=false: print version string
 ```
 

--- a/contrib/google_auth_proxy.cfg.example
+++ b/contrib/google_auth_proxy.cfg.example
@@ -46,12 +46,17 @@
 
 
 ## Cookie Settings
-## Secret - the seed string for secure cookies
+## Secret - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##          for use with an AES cipher when cookie_refresh or pass_access_code
+##          is set
 ## Domain - optional cookie domain to force cookies to (ie: .yourcompany.com)
 ## Expire - expire timeframe for cookie
+## Refresh - refresh the cookie when less than this much time remains before
+##           expiration; should be less than cookie_expire; set to 0 to disable
 # cookie_secret = ""
 # cookie_domain = ""
 # cookie_expire = "168h"
+# cookie_refresh = "144h"
 # cookie_secure = true
 # cookie_httponly = true
-
+# pass_access_code = true

--- a/cookies.go
+++ b/cookies.go
@@ -15,11 +15,11 @@ import (
 	"time"
 )
 
-func validateCookie(cookie *http.Cookie, seed string) (string, bool) {
+func validateCookie(cookie *http.Cookie, seed string) (string, time.Time, bool) {
 	// value, timestamp, sig
 	parts := strings.Split(cookie.Value, "|")
 	if len(parts) != 3 {
-		return "", false
+		return "", time.Unix(0, 0), false
 	}
 	sig := cookieSignature(seed, cookie.Name, parts[0], parts[1])
 	if checkHmac(parts[2], sig) {
@@ -28,11 +28,11 @@ func validateCookie(cookie *http.Cookie, seed string) (string, bool) {
 			// it's a valid cookie. now get the contents
 			rawValue, err := base64.URLEncoding.DecodeString(parts[0])
 			if err == nil {
-				return string(rawValue), true
+				return string(rawValue), time.Unix(int64(ts), 0), true
 			}
 		}
 	}
-	return "", false
+	return "", time.Unix(0, 0), false
 }
 
 func signedCookieValue(seed string, key string, value string) string {

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
-	flagSet.Duration("cookie-refresh", time.Duration(24)*time.Hour, "refresh the cookie when this much time remains before expiration")
+	flagSet.Duration("cookie-refresh", time.Duration(0)*time.Hour, "refresh the cookie when this much time remains before expiration")
 	flagSet.Bool("cookie-https-only", true, "set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
+	flagSet.Duration("cookie-refresh", time.Duration(24)*time.Hour, "refresh the cookie when this much time remains before expiration")
 	flagSet.Bool("cookie-https-only", true, "set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
-	flagSet.Duration("cookie-refresh", time.Duration(0)*time.Hour, "refresh the cookie when this much time remains before expiration")
+	flagSet.Duration("cookie-refresh", time.Duration(0)*time.Hour, "refresh the cookie when less than this much time remains before expiration; 0 to disable")
 	flagSet.Bool("cookie-https-only", true, "set secure (HTTPS) cookies (deprecated. use --cookie-secure setting)")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")
+	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "Oauth scope specification")
 
 	flagSet.Parse(os.Args[1:])

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -262,6 +262,27 @@ func (p *OauthProxy) SetCookie(rw http.ResponseWriter, req *http.Request, val st
 	http.SetCookie(rw, p.MakeCookie(req, val, p.CookieExpire))
 }
 
+func (p *OauthProxy) ValidateToken(access_token string) bool {
+	if access_token == "" || p.oauthValidateUrl == nil {
+		return false
+	}
+
+	req, err := http.NewRequest("GET",
+		p.oauthValidateUrl.String()+"?access_token="+access_token, nil)
+	if err != nil {
+		log.Printf("failed building token validation request: %s", err)
+		return false
+	}
+
+	httpclient := &http.Client{}
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		log.Printf("token validation request failed: %s", err)
+		return false
+	}
+	return resp.StatusCode == 200
+}
+
 func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (email, user, access_token string, ok bool) {
 	var value string
 	var timestamp time.Time

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -128,7 +128,7 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 		aes_cipher, err = aes.NewCipher([]byte(opts.CookieSecret))
 		if err != nil {
 			log.Fatal("error creating AES cipher with "+
-				"pass_access_token == true: %s", err)
+				"cookie-secret ", opts.CookieSecret, ": ", err)
 		}
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -40,6 +40,7 @@ type OauthProxy struct {
 	provider            providers.Provider
 	oauthRedemptionUrl  *url.URL // endpoint to redeem the code
 	oauthLoginUrl       *url.URL // to redirect the user to
+	oauthValidateUrl    *url.URL // to validate the access token
 	oauthScope          string
 	clientID            string
 	clientSecret        string
@@ -146,6 +147,7 @@ func NewOauthProxy(opts *Options, validator func(string) bool) *OauthProxy {
 		provider:           opts.provider,
 		oauthRedemptionUrl: opts.provider.Data().RedeemUrl,
 		oauthLoginUrl:      opts.provider.Data().LoginUrl,
+		oauthValidateUrl:   opts.provider.Data().ValidateUrl,
 		serveMux:           serveMux,
 		redirectUrl:        redirectUrl,
 		skipAuthRegex:      opts.SkipAuthRegex,

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -299,7 +299,10 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 	} else if p.CookieRefresh != time.Duration(0) {
 		refresh_threshold := time.Now().Add(p.CookieRefresh)
 		if refresh_threshold.Unix() > timestamp.Unix() {
-			p.SetCookie(rw, req, value)
+			ok = p.ValidateToken(access_token)
+			if ok {
+				p.SetCookie(rw, req, value)
+			}
 		}
 	}
 	return

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -302,7 +302,7 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 	} else if p.CookieRefresh != time.Duration(0) {
 		refresh_threshold := time.Now().Add(p.CookieRefresh)
 		if refresh_threshold.Unix() > timestamp.Unix() {
-			ok = p.ValidateToken(access_token)
+			ok = p.Validator(email) && p.ValidateToken(access_token)
 			if ok {
 				p.SetCookie(rw, req, value)
 			}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -298,6 +298,7 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 	}
 	if err != nil {
 		log.Printf(err.Error())
+		ok = false
 	} else if p.CookieRefresh != time.Duration(0) {
 		refresh_threshold := time.Now().Add(p.CookieRefresh)
 		if refresh_threshold.Unix() > timestamp.Unix() {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -300,8 +300,9 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 		log.Printf(err.Error())
 		ok = false
 	} else if p.CookieRefresh != time.Duration(0) {
+		expires := timestamp.Add(p.CookieExpire)
 		refresh_threshold := time.Now().Add(p.CookieRefresh)
-		if refresh_threshold.Unix() > timestamp.Unix() {
+		if refresh_threshold.Unix() > expires.Unix() {
 			ok = p.Validator(email) && p.ValidateToken(access_token)
 			if ok {
 				p.SetCookie(rw, req, value)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -266,10 +266,10 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 		if ok {
 			email, user, access_token, err = parseCookieValue(
 				value, p.AesCipher)
-			if err != nil {
-				log.Printf(err.Error())
-			}
 		}
+	}
+	if err != nil {
+		log.Printf(err.Error())
 	}
 	return
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -474,6 +474,17 @@ func TestProcessCookieNoCookieError(t *testing.T) {
 	assert.Equal(t, false, ok)
 }
 
+func TestProcessCookieFailIfParsingCookieValueFails(t *testing.T) {
+	pc_test := NewProcessCookieTest()
+	value, _ := buildCookieValue("michael.bland@gsa.gov",
+		pc_test.proxy.AesCipher, "my_access_token")
+	pc_test.req.AddCookie(pc_test.proxy.MakeCookie(
+		pc_test.req, value+"some bogus bytes",
+		pc_test.opts.CookieExpire))
+	_, _, _, ok := pc_test.ProcessCookie()
+	assert.Equal(t, false, ok)
+}
+
 func TestProcessCookieRefreshNotSet(t *testing.T) {
 	pc_test := NewProcessCookieTest()
 	pc_test.InstantiateBackend()

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -353,8 +353,31 @@ func TestProcessCookie(t *testing.T) {
 	assert.Equal(t, "michael.bland", user)
 }
 
-func TestProcessCookieError(t *testing.T) {
+func TestProcessCookieNoCookieError(t *testing.T) {
 	pc_test := NewProcessCookieTest()
 	_, _, _, ok := pc_test.ProcessCookie()
 	assert.Equal(t, false, ok)
+}
+
+func TestProcessCookieRefreshNotSet(t *testing.T) {
+	pc_test := NewProcessCookieTest()
+	cookie := pc_test.MakeCookie("michael.bland@gsa.gov")
+	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
+	pc_test.req.AddCookie(cookie)
+
+	_, _, _, ok := pc_test.ProcessCookie()
+	assert.Equal(t, true, ok)
+	assert.Equal(t, []string(nil), pc_test.rw.HeaderMap["Set-Cookie"])
+}
+
+func TestProcessCookieRefresh(t *testing.T) {
+	pc_test := NewProcessCookieTest()
+	cookie := pc_test.MakeCookie("michael.bland@gsa.gov")
+	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
+	pc_test.req.AddCookie(cookie)
+
+	pc_test.proxy.CookieRefresh = time.Duration(24) * time.Hour
+	_, _, _, ok := pc_test.ProcessCookie()
+	assert.Equal(t, true, ok)
+	assert.NotEqual(t, []string(nil), pc_test.rw.HeaderMap["Set-Cookie"])
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -407,14 +407,19 @@ func NewProcessCookieTest() *ProcessCookieTest {
 	pc_test.opts.CookieSecret = "foobar"
 	pc_test.opts.ClientID = "bazquux"
 	pc_test.opts.ClientSecret = "xyzzyplugh"
-	pc_test.opts.PassAccessToken = true
 	pc_test.opts.CookieSecret = "0123456789abcdef"
+	// First, set the CookieRefresh option so proxy.AesCipher is created,
+	// needed to encrypt the access_token.
+	pc_test.opts.CookieRefresh = time.Duration(24) * time.Hour
 	pc_test.opts.Validate()
 
 	pc_test.proxy = NewOauthProxy(pc_test.opts, func(email string) bool {
 		return true
 	})
 
+	// Now, zero-out proxy.CookieRefresh for the cases that don't involve
+	// access_token validation.
+	pc_test.proxy.CookieRefresh = time.Duration(0)
 	pc_test.rw = httptest.NewRecorder()
 	pc_test.req, _ = http.NewRequest("GET", "/", strings.NewReader(""))
 	return &pc_test

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -492,8 +492,8 @@ func TestProcessCookieRefreshNotSet(t *testing.T) {
 	pc_test.InstantiateBackend()
 	defer pc_test.Close()
 
+	pc_test.proxy.CookieExpire = time.Duration(23) * time.Hour
 	cookie := pc_test.MakeCookie("michael.bland@gsa.gov", "")
-	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
 	pc_test.req.AddCookie(cookie)
 
 	_, _, _, ok := pc_test.ProcessCookie()
@@ -506,8 +506,8 @@ func TestProcessCookieRefresh(t *testing.T) {
 	pc_test.InstantiateBackend()
 	defer pc_test.Close()
 
+	pc_test.proxy.CookieExpire = time.Duration(23) * time.Hour
 	cookie := pc_test.MakeCookie("michael.bland@gsa.gov", "my_access_token")
-	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
 	pc_test.req.AddCookie(cookie)
 
 	pc_test.proxy.CookieRefresh = time.Duration(24) * time.Hour
@@ -516,14 +516,29 @@ func TestProcessCookieRefresh(t *testing.T) {
 	assert.NotEqual(t, []string(nil), pc_test.rw.HeaderMap["Set-Cookie"])
 }
 
+func TestProcessCookieRefreshThresholdNotCrossed(t *testing.T) {
+	pc_test := NewProcessCookieTest()
+	pc_test.InstantiateBackend()
+	defer pc_test.Close()
+
+	pc_test.proxy.CookieExpire = time.Duration(25) * time.Hour
+	cookie := pc_test.MakeCookie("michael.bland@gsa.gov", "my_access_token")
+	pc_test.req.AddCookie(cookie)
+
+	pc_test.proxy.CookieRefresh = time.Duration(24) * time.Hour
+	_, _, _, ok := pc_test.ProcessCookie()
+	assert.Equal(t, true, ok)
+	assert.Equal(t, []string(nil), pc_test.rw.HeaderMap["Set-Cookie"])
+}
+
 func TestProcessCookieFailIfRefreshSetAndTokenNoLongerValid(t *testing.T) {
 	pc_test := NewProcessCookieTest()
 	pc_test.InstantiateBackend()
 	defer pc_test.Close()
 	pc_test.response_code = 401
 
+	pc_test.proxy.CookieExpire = time.Duration(23) * time.Hour
 	cookie := pc_test.MakeCookie("michael.bland@gsa.gov", "my_access_token")
-	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
 	pc_test.req.AddCookie(cookie)
 
 	pc_test.proxy.CookieRefresh = time.Duration(24) * time.Hour
@@ -538,8 +553,8 @@ func TestProcessCookieFailIfRefreshSetAndUserNoLongerValid(t *testing.T) {
 	defer pc_test.Close()
 	pc_test.validate_user = false
 
+	pc_test.proxy.CookieExpire = time.Duration(23) * time.Hour
 	cookie := pc_test.MakeCookie("michael.bland@gsa.gov", "my_access_token")
-	cookie.Expires = time.Now().Add(time.Duration(23) * time.Hour)
 	pc_test.req.AddCookie(cookie)
 
 	pc_test.proxy.CookieRefresh = time.Duration(24) * time.Hour

--- a/options.go
+++ b/options.go
@@ -137,6 +137,14 @@ func (o *Options) Validate() error {
 		}
 	}
 
+	if o.CookieRefresh >= o.CookieExpire {
+		msgs = append(msgs, fmt.Sprintf(
+			"cookie_refresh (%s) must be less than "+
+				"cookie_expire (%s)",
+			o.CookieRefresh.String(),
+			o.CookieExpire.String()))
+	}
+
 	if len(msgs) != 0 {
 		return fmt.Errorf("Invalid configuration:\n  %s",
 			strings.Join(msgs, "\n  "))

--- a/options.go
+++ b/options.go
@@ -39,11 +39,12 @@ type Options struct {
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
-	Provider   string `flag:"provider" cfg:"provider"`
-	LoginUrl   string `flag:"login-url" cfg:"login_url"`
-	RedeemUrl  string `flag:"redeem-url" cfg:"redeem_url"`
-	ProfileUrl string `flag:"profile-url" cfg:"profile_url"`
-	Scope      string `flag:"scope" cfg:"scope"`
+	Provider    string `flag:"provider" cfg:"provider"`
+	LoginUrl    string `flag:"login-url" cfg:"login_url"`
+	RedeemUrl   string `flag:"redeem-url" cfg:"redeem_url"`
+	ProfileUrl  string `flag:"profile-url" cfg:"profile_url"`
+	ValidateUrl string `flag:"validate-url" cfg:"validate_url"`
+	Scope       string `flag:"scope" cfg:"scope"`
 
 	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
@@ -148,6 +149,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	p.LoginUrl, msgs = parseUrl(o.LoginUrl, "login", msgs)
 	p.RedeemUrl, msgs = parseUrl(o.RedeemUrl, "redeem", msgs)
 	p.ProfileUrl, msgs = parseUrl(o.ProfileUrl, "profile", msgs)
+	p.ValidateUrl, msgs = parseUrl(o.ValidateUrl, "validate", msgs)
 	o.provider = providers.New(o.Provider, p)
 	return msgs
 }

--- a/options.go
+++ b/options.go
@@ -120,7 +120,7 @@ func (o *Options) Validate() error {
 	}
 	msgs = parseProviderInfo(o, msgs)
 
-	if o.PassAccessToken {
+	if o.PassAccessToken || (o.CookieRefresh != time.Duration(0)) {
 		valid_cookie_secret_size := false
 		for _, i := range []int{16, 24, 32} {
 			if len(o.CookieSecret) == i {
@@ -131,8 +131,8 @@ func (o *Options) Validate() error {
 			msgs = append(msgs, fmt.Sprintf(
 				"cookie_secret must be 16, 24, or 32 bytes "+
 					"to create an AES cipher when "+
-					"pass_access_token == true, "+
-					"but is %d bytes",
+					"pass_access_token == true or "+
+					"cookie_refresh != 0, but is %d bytes",
 				len(o.CookieSecret)))
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	CookieSecret    string        `flag:"cookie-secret" cfg:"cookie_secret" env:"GOOGLE_AUTH_PROXY_COOKIE_SECRET"`
 	CookieDomain    string        `flag:"cookie-domain" cfg:"cookie_domain" env:"GOOGLE_AUTH_PROXY_COOKIE_DOMAIN"`
 	CookieExpire    time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"GOOGLE_AUTH_PROXY_COOKIE_EXPIRE"`
+	CookieRefresh   time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"GOOGLE_AUTH_PROXY_COOKIE_REFRESH"`
 	CookieHttpsOnly bool          `flag:"cookie-https-only" cfg:"cookie_https_only"` // deprecated use cookie-secure
 	CookieSecure    bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHttpOnly  bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
@@ -61,6 +62,7 @@ func NewOptions() *Options {
 		CookieSecure:        true,
 		CookieHttpOnly:      true,
 		CookieExpire:        time.Duration(168) * time.Hour,
+		CookieRefresh:       time.Duration(0),
 		PassBasicAuth:       true,
 		PassAccessToken:     false,
 		PassHostHeader:      true,

--- a/options_test.go
+++ b/options_test.go
@@ -112,6 +112,10 @@ func TestPassAccessTokenRequiresSpecificCookieSecretLengths(t *testing.T) {
 	o.CookieSecret = "cookie of invalid length-"
 	assert.NotEqual(t, nil, o.Validate())
 
+	o.PassAccessToken = false
+	o.CookieRefresh = time.Duration(24) * time.Hour
+	assert.NotEqual(t, nil, o.Validate())
+
 	o.CookieSecret = "16 bytes AES-128"
 	assert.Equal(t, nil, o.Validate())
 

--- a/options_test.go
+++ b/options_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bmizerany/assert"
 )
@@ -123,5 +124,17 @@ func TestPassAccessTokenRequiresSpecificCookieSecretLengths(t *testing.T) {
 	assert.Equal(t, nil, o.Validate())
 
 	o.CookieSecret = "32 byte secret for AES-256------"
+	assert.Equal(t, nil, o.Validate())
+}
+
+func TestCookieRefreshMustBeLessThanCookieExpire(t *testing.T) {
+	o := testOptions()
+	assert.Equal(t, nil, o.Validate())
+
+	o.CookieSecret = "0123456789abcdef"
+	o.CookieRefresh = o.CookieExpire
+	assert.NotEqual(t, nil, o.Validate())
+
+	o.CookieRefresh -= time.Duration(1)
 	assert.Equal(t, nil, o.Validate())
 }

--- a/providers/google.go
+++ b/providers/google.go
@@ -24,6 +24,11 @@ func NewGoogleProvider(p *ProviderData) *GoogleProvider {
 			Host: "accounts.google.com",
 			Path: "/o/oauth2/token"}
 	}
+	if p.ValidateUrl.String() == "" {
+		p.ValidateUrl = &url.URL{Scheme: "https",
+			Host: "www.googleapis.com",
+			Path: "/oauth2/v1/tokeninfo"}
+	}
 	if p.Scope == "" {
 		p.Scope = "profile email"
 	}

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -15,6 +15,7 @@ func newGoogleProvider() *GoogleProvider {
 			LoginUrl:     &url.URL{},
 			RedeemUrl:    &url.URL{},
 			ProfileUrl:   &url.URL{},
+			ValidateUrl:  &url.URL{},
 			Scope:        ""})
 }
 
@@ -26,6 +27,8 @@ func TestGoogleProviderDefaults(t *testing.T) {
 		p.Data().LoginUrl.String())
 	assert.Equal(t, "https://accounts.google.com/o/oauth2/token",
 		p.Data().RedeemUrl.String())
+	assert.Equal(t, "https://www.googleapis.com/oauth2/v1/tokeninfo",
+		p.Data().ValidateUrl.String())
 	assert.Equal(t, "", p.Data().ProfileUrl.String())
 	assert.Equal(t, "profile email", p.Data().Scope)
 }
@@ -45,6 +48,10 @@ func TestGoogleProviderOverrides(t *testing.T) {
 				Scheme: "https",
 				Host:   "example.com",
 				Path:   "/oauth/profile"},
+			ValidateUrl: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
 			Scope: "profile"})
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "Google", p.Data().ProviderName)
@@ -54,6 +61,8 @@ func TestGoogleProviderOverrides(t *testing.T) {
 		p.Data().RedeemUrl.String())
 	assert.Equal(t, "https://example.com/oauth/profile",
 		p.Data().ProfileUrl.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateUrl.String())
 	assert.Equal(t, "profile", p.Data().Scope)
 }
 

--- a/providers/myusa.go
+++ b/providers/myusa.go
@@ -32,6 +32,11 @@ func NewMyUsaProvider(p *ProviderData) *MyUsaProvider {
 			Host: myUsaHost,
 			Path: "/api/v1/profile"}
 	}
+	if p.ValidateUrl.String() == "" {
+		p.ValidateUrl = &url.URL{Scheme: "https",
+			Host: myUsaHost,
+			Path: "/api/v1/tokeninfo"}
+	}
 	if p.Scope == "" {
 		p.Scope = "profile.email"
 	}

--- a/providers/myusa_test.go
+++ b/providers/myusa_test.go
@@ -21,11 +21,13 @@ func testMyUsaProvider(hostname string) *MyUsaProvider {
 			LoginUrl:     &url.URL{},
 			RedeemUrl:    &url.URL{},
 			ProfileUrl:   &url.URL{},
+			ValidateUrl:  &url.URL{},
 			Scope:        ""})
 	if hostname != "" {
 		updateUrl(p.Data().LoginUrl, hostname)
 		updateUrl(p.Data().RedeemUrl, hostname)
 		updateUrl(p.Data().ProfileUrl, hostname)
+		updateUrl(p.Data().ValidateUrl, hostname)
 	}
 	return p
 }
@@ -56,6 +58,8 @@ func TestMyUsaProviderDefaults(t *testing.T) {
 		p.Data().RedeemUrl.String())
 	assert.Equal(t, "https://alpha.my.usa.gov/api/v1/profile",
 		p.Data().ProfileUrl.String())
+	assert.Equal(t, "https://alpha.my.usa.gov/api/v1/tokeninfo",
+		p.Data().ValidateUrl.String())
 	assert.Equal(t, "profile.email", p.Data().Scope)
 }
 
@@ -74,6 +78,10 @@ func TestMyUsaProviderOverrides(t *testing.T) {
 				Scheme: "https",
 				Host:   "example.com",
 				Path:   "/oauth/profile"},
+			ValidateUrl: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
 			Scope: "profile"})
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "MyUSA", p.Data().ProviderName)
@@ -83,6 +91,8 @@ func TestMyUsaProviderOverrides(t *testing.T) {
 		p.Data().RedeemUrl.String())
 	assert.Equal(t, "https://example.com/oauth/profile",
 		p.Data().ProfileUrl.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateUrl.String())
 	assert.Equal(t, "profile", p.Data().Scope)
 }
 

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -9,6 +9,7 @@ type ProviderData struct {
 	LoginUrl     *url.URL
 	RedeemUrl    *url.URL
 	ProfileUrl   *url.URL
+	ValidateUrl  *url.URL
 	Scope        string
 }
 


### PR DESCRIPTION
Hi @jehiah, at the prompting of a non-technical colleague at work (@lsgitter) and after being inspired by an idea from @adelevie, I've taken a stab at a new `cookie-refresh` flag. The idea is that the cookie's expiration date would automatically get updated whenever the user accesses an authenticated page within some window of time before it expires.

As you'll see, the first three commits are all refactorings; the one after that adds a test for the existing behavior; and the final commit is where the `cookie-refresh` feature is added.

Good idea? Bad idea? 